### PR TITLE
Typos in docstrings and parameters

### DIFF
--- a/docs/pages/tutorial_01_quickstart/tutorial_01_quickstart.rst
+++ b/docs/pages/tutorial_01_quickstart/tutorial_01_quickstart.rst
@@ -247,7 +247,7 @@ to :math:`t=5\,\Omega^{-1}`
                                        initial_state=tempo.operators.spin_dm("up"),
                                        start_time=0.0,
                                        end_time=5.0,
-                                       tollerance=0.01)
+                                       tolerance=0.01)
 
 
 .. parsed-literal::
@@ -296,7 +296,7 @@ Let’s have a look at the above warning. It said:
 
 We got this message because we didn’t tell the package what parameters
 to use for the TEMPO computation, but instead only specified a
-``tollerance``. The package tries it’s best by implicitly calling the
+``tolerance``. The package tries it’s best by implicitly calling the
 function ``tempo.guess_tempo_parameters()`` to find parameters that are
 appropriate for the spectral density and system objects given.
 
@@ -330,7 +330,7 @@ whether it satisfies the above requirements:
                                               bath=bath_A,
                                               start_time=0.0,
                                               end_time=5.0,
-                                              tollerance=0.01)
+                                              tolerance=0.01)
     print(parameters)
 
 

--- a/examples/details_tempo.ipynb
+++ b/examples/details_tempo.ipynb
@@ -289,7 +289,7 @@
     "                                        bath=bath_A,\n",
     "                                        start_time=0.0,\n",
     "                                        end_time=15.0,\n",
-    "                                        tollerance=1.0e-2)"
+    "                                        tolerance=1.0e-2)"
    ]
   },
   {
@@ -310,7 +310,7 @@
     "                                        bath=bath_A,\n",
     "                                        start_time=0.0,\n",
     "                                        end_time=15.0,\n",
-    "                                        tollerance=1.0e-3)"
+    "                                        tolerance=1.0e-3)"
    ]
   },
   {

--- a/tests/tempo_test.py
+++ b/tests/tempo_test.py
@@ -128,21 +128,21 @@ def test_guess_tempo_parameters():
         param = tempo.guess_tempo_parameters(bath=bath,
                                              start_time=10.0,
                                              end_time=0.0)
-    with pytest.raises(AssertionError): # bad tollerance
+    with pytest.raises(AssertionError): # bad tolerance
         param = tempo.guess_tempo_parameters(bath=bath,
                                              start_time=0.0,
                                              end_time=15.0,
-                                             tollerance="bla")
-    with pytest.raises(AssertionError): # bad tollerance (negative)
+                                             tolerance="bla")
+    with pytest.raises(AssertionError): # bad tolerance (negative)
         param = tempo.guess_tempo_parameters(bath=bath,
                                              start_time=0.0,
                                              end_time=15.0,
-                                             tollerance=-0.2)
+                                             tolerance=-0.2)
     with pytest.warns(UserWarning): # reach MAX_DKMAX
         param = tempo.guess_tempo_parameters(bath=bath,
                                              start_time=0.0,
                                              end_time=15.0,
-                                             tollerance=1.0e-12)
+                                             tolerance=1.0e-12)
 
 def test_tempo_compute():
     start_time = -0.3

--- a/time_evolving_mpo/config.py
+++ b/time_evolving_mpo/config.py
@@ -21,10 +21,10 @@ from numpy import float64, complex128
 NpDtype = complex128
 NpDtypeReal = float64
 
-# Seperator string for __str__ functions
+# Separator string for __str__ functions
 SEPERATOR = "----------------------------------------------\n"
 
-# relative precission for np.integrate.quad()
+# relative precision for np.integrate.quad()
 INTEGRATE_EPSREL = 2**(-26)
 
 # maximal number of subdivision for adaptive np.integrate.quad()

--- a/time_evolving_mpo/correlations.py
+++ b/time_evolving_mpo/correlations.py
@@ -53,7 +53,7 @@ class BaseCorrelations(BaseAPIClass):
         tau : ndarray
             Time difference :math:`\tau`
         epsrel : float
-            Relative error tollerance.
+            Relative error tolerance.
         subdiv_limit: int
             Maximal number of interval subdivisions for numerical integration.
 
@@ -106,7 +106,7 @@ class BaseCorrelations(BaseAPIClass):
             The shape of the 2D integral. Shapes are: {``'square'``,
             ``'upper-triangle'``, ``'lower-triangle'``, ``'lower-triangle'``}
         epsrel : float
-            Relative error tollerance.
+            Relative error tolerance.
         subdiv_limit: int
             Maximal number of interval subdivisions for numerical integration.
 
@@ -224,7 +224,7 @@ class CustomCorrelations(BaseCorrelations):
         tau : ndarray
             Time difference :math:`\tau`
         epsrel : float
-            Relative error tollerance (has no effect here).
+            Relative error tolerance (has no effect here).
         subdiv_limit : int
             Maximal number of interval subdivisions for numerical integration
             (has no effect here).
@@ -278,7 +278,7 @@ class CustomCorrelations(BaseCorrelations):
             The shape of the 2D integral. Shapes are: {``'square'``,
             ``'upper-triangle'``, ``'lower-triangle'``, ``'lower-triangle'``}
         epsrel : float
-            Relative error tollerance.
+            Relative error tolerance.
         subdiv_limit: int
             Maximal number of interval subdivisions for numerical integration.
 
@@ -660,9 +660,9 @@ class CustomSD(BaseCorrelations):
         tau : ndarray
             Time difference :math:`\tau`
         epsrel : float (default = 1.49e-08)
-            Relative error tollerance.
+            Relative error tolerance.
         epsrel : float
-            Relative error tollerance.
+            Relative error tolerance.
         subdiv_limit: int
             Maximal number of interval subdivisions for numerical integration.
 
@@ -745,7 +745,7 @@ class CustomSD(BaseCorrelations):
             The shape of the 2D integral. Shapes are: {``'square'``,
             ``'upper-triangle'``, ``'lower-triangle'``, ``'lower-triangle'``}
         epsrel : float
-            Relative error tollerance.
+            Relative error tolerance.
         subdiv_limit: int
             Maximal number of interval subdivisions for numerical integration.
 

--- a/time_evolving_mpo/correlations.py
+++ b/time_evolving_mpo/correlations.py
@@ -96,7 +96,7 @@ class BaseCorrelations(BaseAPIClass):
         Parameters
         ----------
         delta : float
-            Length of integration intevals.
+            Length of integration intervals.
         time_1 : float
             Lower bound of integration interval of :math:`dt'`.
         time_2 : float
@@ -165,7 +165,7 @@ class CustomCorrelations(BaseCorrelations):
     correlation_function : callable
         The correlation function :math:`C`.
     max_correlation_time : float
-        The maximal occuring correlation time :math:`\tau_\mathrm{max}`.
+        The maximal occurring correlation time :math:`\tau_\mathrm{max}`.
     name: str
         An optional name for the correlations.
     description: str
@@ -268,7 +268,7 @@ class CustomCorrelations(BaseCorrelations):
         Parameters
         ----------
         delta : float
-            Length of integration intevals.
+            Length of integration intervals.
         time_1 : float
             Lower bound of integration interval of :math:`dt'`.
         time_2 : float
@@ -295,7 +295,7 @@ class CustomCorrelations(BaseCorrelations):
             time_2 = time_1 + delta
         else:
             assert shape == 'rectangle', \
-                "paramter 'time_2' can only be used in conjunction with " \
+                "parameter 'time_2' can only be used in conjunction with " \
                 "'shape' = ``rectangle`` !"
 
         lower_boundary = {'square': lambda x: 0.0,
@@ -549,7 +549,7 @@ class CustomSD(BaseCorrelations):
     temperature: float
         The environment's temperature.
     max_correlation_time : float
-        The maximal occuring correlation time :math:`\tau_\mathrm{max}`.
+        The maximal occurring correlation time :math:`\tau_\mathrm{max}`.
     name: str
         An optional name for the correlations.
     description: str
@@ -659,8 +659,6 @@ class CustomSD(BaseCorrelations):
         ----------
         tau : ndarray
             Time difference :math:`\tau`
-        epsrel : float (default = 1.49e-08)
-            Relative error tolerance.
         epsrel : float
             Relative error tolerance.
         subdiv_limit: int
@@ -735,7 +733,7 @@ class CustomSD(BaseCorrelations):
         Parameters
         ----------
         delta : float
-            Length of integration intevals.
+            Length of integration intervals.
         time_1 : float
             Lower bound of integration interval of :math:`dt'`.
         time_2 : float
@@ -830,7 +828,7 @@ class PowerLawSD(CustomSD):
     Parameters
     ----------
     alpha : float
-        The coupling strenght :math:`\alpha`.
+        The coupling strength :math:`\alpha`.
     zeta : float
         The exponent :math:`\zeta` (corresponds to the dimensionality of the
         environment). The environment is called *ohmic* if :math:`\zeta=1`,
@@ -843,7 +841,7 @@ class PowerLawSD(CustomSD):
     temperature: float
         The environment's temperature.
     max_correlation_time : float
-        The maximal occuring correlation time :math:`\tau_\mathrm{max}`.
+        The maximal occurring correlation time :math:`\tau_\mathrm{max}`.
     name: str
         An optional name for the correlations.
     description: str

--- a/time_evolving_mpo/exceptions.py
+++ b/time_evolving_mpo/exceptions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Custom TEMPO Warings and Errors.
+Custom TEMPO Warnings and Errors.
 """
 
 class NumericsError(Exception):

--- a/time_evolving_mpo/helpers.py
+++ b/time_evolving_mpo/helpers.py
@@ -34,7 +34,7 @@ def plot_correlations_with_parameters(
     Parameters
     ----------
     correlations: BaseCorrelations
-        The correlation obeject we are interested in.
+        The correlation object we are interested in.
     parameters: TempoParameters
         The tempo parameters that determine the grid.
     """

--- a/time_evolving_mpo/pt_tempo.py
+++ b/time_evolving_mpo/pt_tempo.py
@@ -71,7 +71,7 @@ class PtTempoParameters(TempoParameters):
         Number of time steps :math:`K\in\mathbb{N}` that should be included in
         the non-Markovian memory. - It must be large
         enough such that :math:`\delta t \times K` is larger than the
-        neccessary memory time :math:`\tau_\mathrm{cut}`.
+        necessary memory time :math:`\tau_\mathrm{cut}`.
     epsrel: float
         The maximal relative error in the singular value truncation (done
         in the underlying tensor network algorithm). - It must be small enough
@@ -88,7 +88,7 @@ class PtTempo(BaseAPIClass):
     Parameters
     ----------
     bath: Bath
-        The Bath (includes the coupling operator to the sytem).
+        The Bath (includes the coupling operator to the system).
     parameters: PtTempoParameters
         The parameters for the PT-TEMPO computation.
     start_time: float
@@ -235,7 +235,7 @@ class PtTempo(BaseAPIClass):
 
     def compute(self, progress_type: Optional[Text] = None) -> None:
         """
-        Propagate (or continue to propagete) the TEMPO tensor network to
+        Propagate (or continue to propagate) the TEMPO tensor network to
         time `end_time`.
 
         Parameters
@@ -333,7 +333,7 @@ def pt_tempo_compute(
         start_time: float,
         end_time: float,
         parameters: Optional[PtTempoParameters] = None,
-        tollerance: Optional[float] = PT_DEFAULT_TOLLERANCE,
+        tolerance: Optional[float] = PT_DEFAULT_TOLLERANCE,
         backend: Optional[Text] = None,
         backend_config: Optional[Dict] = None,
         progress_type: Optional[Text] = None,
@@ -347,15 +347,15 @@ def pt_tempo_compute(
     Parameters
     ----------
     bath: Bath
-        The Bath (includes the coupling operator to the sytem).
+        The Bath (includes the coupling operator to the system).
     start_time: float
         The start time.
     end_time: float
         The time to which the PT-TEMPO should be computed.
     parameters: PtTempoParameters
         The parameters for the PT-TEMPO computation.
-    tollerance: float
-        Tollerance for the parameter estimation (only applicable if
+    tolerance: float
+        Tolerance for the parameter estimation (only applicable if
         `parameters` is None).
     backend: str (default = None)
         The name of the backend to use for the computation. If `backend` is
@@ -375,13 +375,13 @@ def pt_tempo_compute(
         An optional dictionary with descriptive data.
     """
     if parameters is None:
-        assert tollerance is not None, \
-            "If 'parameters' is 'None' then 'tollerance' must be " \
+        assert tolerance is not None, \
+            "If 'parameters' is 'None' then 'tolerance' must be " \
             + "a positive float."
         parameters = guess_pt_tempo_parameters(bath=bath,
                                                start_time=start_time,
                                                end_time=end_time,
-                                               tollerance=tollerance)
+                                               tolerance=tolerance)
     ptt = PtTempo(bath,
                   start_time,
                   end_time,
@@ -398,7 +398,7 @@ def guess_pt_tempo_parameters(
         bath: Bath,
         start_time: float,
         end_time: float,
-        tollerance: Optional[float] = PT_DEFAULT_TOLLERANCE
+        tolerance: Optional[float] = PT_DEFAULT_TOLLERANCE
         ) -> PtTempoParameters:
     """
     Function to roughly estimate appropriate parameters for a PT-TEMPO
@@ -406,8 +406,8 @@ def guess_pt_tempo_parameters(
 
     .. warning::
 
-        No guarantie that resulting PT-TEMPO calculation converges towards the
-        correct dynamics! Please refere to the TEMPO documentation and check
+        No guarantee that resulting PT-TEMPO calculation converges towards the
+        correct dynamics! Please refer to the TEMPO documentation and check
         convergence by varying the parameters for PT-TEMPO manually.
 
     Parameters
@@ -418,23 +418,23 @@ def guess_pt_tempo_parameters(
         The start time.
     end_time: float
         The time to which the TEMPO should be computed.
-    tollerance: float
-        Tollerance for the parameter estimation.
+    tolerance: float
+        Tolerance for the parameter estimation.
 
     Returns
     -------
     pt_tempo_parameters : TempoParameters
-        Estimate of appropropriate tempo parameters.
+        Estimate of appropriate tempo parameters.
     """
     param = guess_tempo_parameters(
                 bath=bath,
                 start_time=start_time,
                 end_time=end_time,
-                tollerance=tollerance)
+                tolerance=tolerance)
     return PtTempoParameters(
         dt=param.dt,
         dkmax=param.dkmax,
         epsrel=param.epsrel,
         name="Roughly estimated parameters",
         description="Estimated with 'guess_pt_tempo_parameters()'",
-        description_dict={"tollerance":tollerance})
+        description_dict={"tolerance":tolerance})

--- a/time_evolving_mpo/util.py
+++ b/time_evolving_mpo/util.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Module for utillities.
+Module for utilities.
 """
 
 import sys
@@ -76,7 +76,7 @@ def load_object(filename: Text) -> Any:
         return pickle.load(file)
 
 
-# -- progess bar --------------------------------------------------------------
+# -- process bar --------------------------------------------------------------
 
 class BaseProgress:
     """Base class to display computation progress. """
@@ -217,6 +217,6 @@ def get_progress(progress_type: Text = None) -> BaseProgress:
     if progress_type is None:
         progress_type = PROGRESS_TYPE
     assert progress_type in PROGRESS_DICT, \
-        "Unknown progess_type='{}', know are {}".format(
+        "Unknown progress_type='{}', know are {}".format(
             progress_type, PROGRESS_DICT.keys())
     return PROGRESS_DICT[progress_type]

--- a/tutorials/tutorial_01_quickstart.ipynb
+++ b/tutorials/tutorial_01_quickstart.ipynb
@@ -338,7 +338,7 @@
     "                                   initial_state=tempo.operators.spin_dm(\"up\"),\n",
     "                                   start_time=0.0,\n",
     "                                   end_time=5.0,\n",
-    "                                   tollerance=0.01)"
+    "                                   tolerance=0.01)"
    ]
   },
   {
@@ -400,7 +400,7 @@
     "```\n",
     "WARNING: Estimating parameters for TEMPO calculation. No guarantie that resulting TEMPO calculation converges towards the correct dynamics! Please refere to the TEMPO documentation and check convergence by varying the parameters for TEMPO manually.\n",
     "```\n",
-    "We got this message because we didn't tell the package what parameters to use for the TEMPO computation, but instead only specified a `tollerance`. The package tries it's best by implicitly calling the function `tempo.guess_tempo_parameters()` to find parameters that are appropriate for the spectral density and system objects given."
+    "We got this message because we didn't tell the package what parameters to use for the TEMPO computation, but instead only specified a `tolerance`. The package tries it's best by implicitly calling the function `tempo.guess_tempo_parameters()` to find parameters that are appropriate for the spectral density and system objects given."
    ]
   },
   {
@@ -463,7 +463,7 @@
     "                                          bath=bath_A,\n",
     "                                          start_time=0.0,\n",
     "                                          end_time=5.0,\n",
-    "                                          tollerance=0.01)\n",
+    "                                          tolerance=0.01)\n",
     "print(parameters)"
    ]
   },

--- a/tutorials/tutorial_01_quickstart.py
+++ b/tutorials/tutorial_01_quickstart.py
@@ -155,7 +155,7 @@ dynamics_A_1 = tempo.tempo_compute(system=system_A,
                                    initial_state=tempo.operators.spin_dm("up"),
                                    start_time=0.0,
                                    end_time=5.0,
-                                   tollerance=0.01)
+                                   tolerance=0.01)
 
 
 # and plot the result:
@@ -177,7 +177,7 @@ plt.legend()
 # ```
 # WARNING: Estimating parameters for TEMPO calculation. No guarantie that resulting TEMPO calculation converges towards the correct dynamics! Please refere to the TEMPO documentation and check convergence by varying the parameters for TEMPO manually.
 # ```
-# We got this message because we didn't tell the package what parameters to use for the TEMPO computation, but instead only specified a `tollerance`. The package tries it's best by implicitly calling the function `tempo.guess_tempo_parameters()` to find parameters that are appropriate for the spectral density and system objects given.
+# We got this message because we didn't tell the package what parameters to use for the TEMPO computation, but instead only specified a `tolerance`. The package tries it's best by implicitly calling the function `tempo.guess_tempo_parameters()` to find parameters that are appropriate for the spectral density and system objects given.
 
 # #### TEMPO Parameters
 
@@ -198,7 +198,7 @@ parameters = tempo.guess_tempo_parameters(system=system_A,
                                           bath=bath_A,
                                           start_time=0.0,
                                           end_time=5.0,
-                                          tollerance=0.01)
+                                          tolerance=0.01)
 print(parameters)
 
 


### PR DESCRIPTION
Fixed typos across files in `time_evolving_mpo`.

Mainly documentation, but includes renaming the parameter 'tollerance' to 'tolerance'.

No functional changes. All tests passed.
