### PR TITLE
Pr/multi env

### DIFF
--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -61,6 +61,11 @@ def compute_dynamics(
         process_tensors = [process_tensor]
     else:
         process_tensors = process_tensor
+
+    if len(process_tensors) > 1:
+        assert (initial_state is not None), \
+        "For multiple environments an initial state must be specified."
+
     hs_dim = system.dimension
     for pt in process_tensors:
         assert hs_dim == pt.hilbert_space_dimension
@@ -152,9 +157,6 @@ def _compute_dynamics(
     num_envs = len(process_tensors)
     hs_dim = process_tensors[0].hilbert_space_dimension
 
-    if num_envs > 1:
-        assert (initial_state is not None), \
-        "For multiple environments an initial state must be specified."
 
     initial_tensor = process_tensors[0].get_initial_tensor()
     assert (initial_state is None) ^ (initial_tensor is None), \
@@ -248,7 +250,7 @@ def _compute_dynamics(
         for i,lam in enumerate(lams):
             if lam is not None:
                 lam_node = tn.Node(lam)
-                current_bond_legs[i]^lam_node[0]
+                current_bond_legs[i] ^ lam_node[0]
                 current_bond_legs[i] = lam_node[1]
                 current @ lam_node
 
@@ -261,6 +263,7 @@ def _compute_dynamics(
                 +f"for step {step}.")
         cap_node = tn.Node(cap)
         cap_nodes.append(cap_node)
+
     for i in range(num_envs):
         current_bond_legs[i] ^ cap_nodes[i][0]
         current = current @ cap_nodes[i]

--- a/tests/multi_env_test.py
+++ b/tests/multi_env_test.py
@@ -1,0 +1,63 @@
+# Copyright 2021 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test for the time_evovling_mpo.process_tensor module multiple environment 
+functionality.
+"""
+
+import numpy as np
+
+import oqupy
+
+
+# -- prepare process tensors -------------------------------------------------
+
+system = oqupy.System(oqupy.operators.sigma("x"))
+initial_state = oqupy.operators.spin_dm("z+")
+correlations = oqupy.PowerLawSD(alpha=0.05,
+                                zeta=1.0,
+                                cutoff=5.0,
+                                cutoff_type="exponential",
+                                temperature=0.2,
+                                name="ohmic")
+correlations2 = oqupy.PowerLawSD(alpha=0.1,
+                                zeta=1.0,
+                                cutoff=5.0,
+                                cutoff_type="exponential",
+                                temperature=0.2,
+                                name="ohmic")
+bath = oqupy.Bath(0.5*oqupy.operators.sigma("z"),
+                    correlations,
+                    name="phonon bath")
+bath2 = oqupy.Bath(0.5*oqupy.operators.sigma("z"),
+                    correlations2,
+                    name="half-coupling phonon bath")
+tempo_params = oqupy.PtTempoParameters(dt=0.1,
+                                         dkmax=5,
+                                         epsrel=10**(-6))
+pt = oqupy.pt_tempo_compute(bath,
+                            start_time=0.0,
+                            end_time=1.0,
+                            parameters=tempo_params)
+pt2 = oqupy.pt_tempo_compute(bath2,
+                            start_time=0.0,
+                            end_time=1.0,
+                            parameters=tempo_params)
+
+
+def test_multi_env_dynamics():
+    dyns = oqupy.compute_dynamics(system, [pt,pt],initial_state=initial_state)
+    dyns2 = oqupy.compute_dynamics(system, [pt2],initial_state=initial_state)
+    np.testing.assert_almost_equal(dyns.states,dyns2.states,decimal=5)
+


### PR DESCRIPTION
Closes #32. Added multi-environment functionality plus test that combining duplicate process tensors results in one with twice the coupling.

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/TimeEvolvingMPO/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
* [ ] API code contributions include input checks.
* [ ] API code contributions include helpful error messages.
* [ ] The documentation has been updated:
  - [ ] docstring for all functions/methods/classes/modules.
  - [ ] consistant style of all docstrings.
  - [ ] for new modules: `/docs/pages/modules.rst` has been updated.
  - [ ] for api contributions: `/docs/pages/api.rst` has been updated.
  - [ ] for api contributions: tutorials and examples have been updated.
