### PR TITLE
Pr/add control (#8)

### DIFF
--- a/oqupy/__init__.py
+++ b/oqupy/__init__.py
@@ -22,6 +22,9 @@ __all__ = [
     'Bath',
     'CustomCorrelations',
     'CustomSD',
+    'compute_dynamics',
+    'compute_final_state',
+    'Control',
     'Dynamics',
     'FileProcessTensor',
     'guess_pt_tempo_parameters',
@@ -47,36 +50,36 @@ __all__ = [
 
 from oqupy.bath import Bath
 
-# from oqupy.control import Control
-
 from oqupy.contractions import compute_dynamics
 from oqupy.contractions import compute_final_state
+
+from oqupy.control import Control
+
+from oqupy.correlations import CustomCorrelations
+from oqupy.correlations import CustomSD
+from oqupy.correlations import PowerLawSD
 
 from oqupy.dynamics import Dynamics
 
 from oqupy.exceptions import NumericsError
 from oqupy.exceptions import NumericsWarning
 
-import oqupy.operators
-
 import oqupy.helpers
+
+import oqupy.operators
 
 from oqupy.process_tensor import import_process_tensor
 from oqupy.process_tensor import TrivialProcessTensor
 from oqupy.process_tensor import SimpleProcessTensor
 from oqupy.process_tensor import FileProcessTensor
 
+from oqupy.system import System
+from oqupy.system import TimeDependentSystem
+
 from oqupy.tempo.pt_tempo import PtTempo
 from oqupy.tempo.pt_tempo import PtTempoParameters
 from oqupy.tempo.pt_tempo import guess_pt_tempo_parameters
 from oqupy.tempo.pt_tempo import pt_tempo_compute
-
-from oqupy.correlations import CustomCorrelations
-from oqupy.correlations import CustomSD
-from oqupy.correlations import PowerLawSD
-
-from oqupy.system import System
-from oqupy.system import TimeDependentSystem
 
 from oqupy.tempo.tempo import Tempo
 from oqupy.tempo.tempo import TempoParameters

--- a/oqupy/contractions.py
+++ b/oqupy/contractions.py
@@ -284,15 +284,17 @@ def _compute_dynamics(
     else:
         __num_steps = num_steps
 
-    for step in range(__num_steps):
+    for step in range(__num_steps+1):
         # -- apply pre measurement control --
         pre_measurement_control, post_measurement_control = controls(step)
         if pre_measurement_control is not None:
-            raise NotImplementedError() # ToDo
-            # pre_node = tn.Node(pre_measurement_control)
-            # current_state_leg ^ pre_node[0]
-            # current_state_leg = pre_node[1]
-            # current = current @ pre_node
+            pre_node = tn.Node(pre_measurement_control.T)
+            current_state_leg ^ pre_node[0]
+            current_state_leg = pre_node[1]
+            current = current @ pre_node
+
+        if step == __num_steps:
+            break
 
         # -- extract current state --
         if record_all:
@@ -307,7 +309,10 @@ def _compute_dynamics(
 
         # -- apply post measurement control --
         if post_measurement_control is not None:
-            raise NotImplementedError() # ToDo
+            post_node = tn.Node(post_measurement_control.T)
+            current_state_leg ^ post_node[0]
+            current_state_leg = post_node[1]
+            current = current @ post_node
 
         # -- propagate one time step --
         mpo_node = _build_mpo_node(process_tensors, step)
@@ -338,12 +343,6 @@ def _compute_dynamics(
                 current_bond_legs[i] ^ lam_node[0]
                 current_bond_legs[i] = lam_node[1]
                 current @ lam_node
-
-
-    # -- apply last pre measurement control --
-    pre_measurement_control, post_measurement_control = controls(step)
-    if pre_measurement_control is not None:
-        raise NotImplementedError() # ToDo
 
     # -- extract last state --
     cap_nodes = _build_cap(process_tensors, __num_steps)

--- a/oqupy/control.py
+++ b/oqupy/control.py
@@ -15,13 +15,48 @@
 ToDo
 """
 
-pass
-# class Control:
-#     """
-#     ToDo
-#     """
-#     def __init__(self, *args, **kwargs): # ToDo
-#         """
-#         ToDo
-#         """
-#         pass # ToDo
+from typing import Callable, Optional, Tuple, Union
+
+from numpy import ndarray
+
+
+class Control:
+    """
+    ToDo
+    """
+    def __init__(self, dimension: int) -> None:
+        """
+        ToDo
+        """
+        pass # ToDo
+
+    def add_single(
+            self,
+            control_operation: ndarray,
+            time: Union[int, float],
+            pre: Optional[bool] = True) -> None:
+        """
+        ToDo
+        """
+        pass# ToDo
+
+    def add_continuous(
+            self,
+            control_fct: Callable[[ndarray, float], ndarray],
+            pre: Optional[bool] = True) -> None:
+        """
+        ToDo
+        """
+        pass# ToDo
+
+    def get_controls(
+            self,
+            step: int,
+            dt: Optional[float] = None,
+            start_time: Optional[float] = 0.0,
+            ) -> Tuple[ndarray, ndarray]:
+        """
+        ToDo
+        """
+        pass # ToDo
+        return None, None

--- a/oqupy/control.py
+++ b/oqupy/control.py
@@ -15,30 +15,68 @@
 ToDo
 """
 
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Text, Tuple, Union
 
+import numpy as np
 from numpy import ndarray
 
+from oqupy.base_api import BaseAPIClass
 
-class Control:
+
+class Control(BaseAPIClass):
     """
     ToDo
     """
-    def __init__(self, dimension: int) -> None:
-        """
-        ToDo
-        """
-        pass # ToDo
+    def __init__(
+            self,
+            dimension: int,
+            name: Optional[Text] = None,
+            description: Optional[Text] = None,
+            description_dict: Optional[Dict] = None) -> None:
+        """Creates a Control object. """
+        self._dimension = dimension
+        self._step_controls = {'pre':{}, 'post':{}}
+        self._time_controls = {'pre':{}, 'post':{}}
+        self._control_times = {'pre':np.array([]), 'post':np.array([])}
+        super().__init__(name, description, description_dict)
+
+    @property
+    def dimension(self):
+        """Hilbert space dimension of the controlled system. """
+        return self._dimension
 
     def add_single(
             self,
-            control_operation: ndarray,
             time: Union[int, float],
-            pre: Optional[bool] = True) -> None:
+            control_operation: ndarray,
+            post: Optional[bool] = False) -> None:
         """
         ToDo
         """
-        pass# ToDo
+        if post:
+            pre_post = 'post'
+        else:
+            pre_post = 'pre'
+
+        if isinstance(time, int):
+            steps = self._step_controls[pre_post].keys()
+            if time in steps:
+                self._step_controls[pre_post][time] = \
+                    control_operation @ self._step_controls[pre_post][time]
+            else:
+                self._step_controls[pre_post][time] = control_operation
+        elif isinstance(time, float):
+            if time in self._control_times[pre_post]:
+                self._time_controls[pre_post][time] = \
+                    control_operation @ self._time_controls[pre_post][time]
+            else:
+                self._time_controls[pre_post][time] = control_operation
+                times = np.append(self._control_times[pre_post], time)
+                times.sort()
+                self._control_times[pre_post] = times
+        else:
+            raise TypeError("Parameter `time` must be either int or float.")
+
 
     def add_continuous(
             self,
@@ -47,7 +85,7 @@ class Control:
         """
         ToDo
         """
-        pass# ToDo
+        raise NotImplementedError()
 
     def get_controls(
             self,
@@ -58,5 +96,44 @@ class Control:
         """
         ToDo
         """
-        pass # ToDo
-        return None, None
+        pre_control_bool = False
+        post_control_bool = False
+        pre_control = np.identity(self.dimension**2)
+        post_control = np.identity(self.dimension**2)
+
+        # -- pre time-stamp controls --
+        a = np.round((self._control_times['pre'] - start_time) / dt)
+        times = np.array(self._control_times['pre'])[np.nonzero(a==step)]
+        if len(times) > 0:
+            print(times)
+            pre_control_bool = True
+            pre_control = self._time_controls['pre'][times[0]] @ pre_control
+            for t in times[1:]:
+                pre_control = self._time_controls['pre'][t] @ pre_control
+
+        # -- pre step controls --
+        steps = self._step_controls['pre'].keys()
+        if step in steps:
+            pre_control_bool = True
+            pre_control = self._step_controls['pre'][step] @ pre_control
+
+        # -- post step controls --
+        steps = self._step_controls['post'].keys()
+        if step in steps:
+            post_control_bool = True
+            post_control = self._step_controls['post'][step] @ post_control
+
+        # -- post time-stamp controls --
+        a = np.round((self._control_times['post'] - start_time) / dt)
+        times = np.array(self._control_times['post'])[np.nonzero(a==step)]
+        if len(times) > 0:
+            post_control_bool = True
+            post_control = self._time_controls['post'][times[0]] @ post_control
+            for t in times[1:]:
+                post_control = self._time_controls['post'][t] @ post_control
+
+        if not pre_control_bool:
+            pre_control = None
+        if not post_control_bool:
+            post_control = None
+        return pre_control, post_control

--- a/oqupy/operators.py
+++ b/oqupy/operators.py
@@ -154,3 +154,10 @@ def left_right_super(
         right_operator: ndarray) -> ndarray:
     """Construct left and right acting superoperator from operators. """
     return np.kron(left_operator, right_operator.T)
+
+def preparation(
+        density_matrix: ndarray) -> ndarray:
+    """Construct the super operator that prepares the state. """
+    dim = density_matrix.shape[0]
+    identity_matrix = np.identity(dim, dtype=NpDtype)
+    return np.outer(density_matrix.flatten(), identity_matrix.flatten())


### PR DESCRIPTION
Implement core functionality of "control operations" (see #8). Documentation and tests are still missing. But because #31 and #33 depend on this, it would be good to merge to allow development of #31 and #33.

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/TimeEvolvingMPO/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [ ] Added test for changed/added code.
* [ ] API code contributions include input checks.
* [ ] API code contributions include helpful error messages.
* [ ] The documentation has been updated:
  - [ ] docstring for all functions/methods/classes/modules.
  - [ ] consistant style of all docstrings.
  - [ ] for new modules: `/docs/pages/modules.rst` has been updated.
  - [ ] for api contributions: `/docs/pages/api.rst` has been updated.
  - [ ] for api contributions: tutorials and examples have been updated.
