### PR TITLE
Pr/two time correlations (#31)

### DIFF
--- a/docs/pages/modules.rst
+++ b/docs/pages/modules.rst
@@ -1,14 +1,14 @@
 All Modules
 ===========
 
-tempo.base_api
+oqupy.base_api
 --------------
 
 .. automodule:: oqupy.base_api
     :members:
 
 
-tempo.bath
+oqupy.bath
 ----------
 
 .. automodule:: oqupy.bath
@@ -16,7 +16,15 @@ tempo.bath
     :members:
 
 
-tempo.correlations
+oqupy.contractions
+------------------
+
+.. automodule:: oqupy.contractions
+    :show-inheritance:
+    :members:
+
+
+oqupy.correlations
 ------------------
 
 .. automodule:: oqupy.correlations
@@ -24,7 +32,7 @@ tempo.correlations
     :members:
 
 
-tempo.dynamics
+oqupy.dynamics
 --------------
 
 .. automodule:: oqupy.dynamics
@@ -32,7 +40,7 @@ tempo.dynamics
     :members:
 
 
-tempo.exceptions
+oqupy.exceptions
 ----------------
 
 .. automodule:: oqupy.exceptions
@@ -40,28 +48,28 @@ tempo.exceptions
     :members:
 
 
-tempo.file_formats
+oqupy.file_formats
 ------------------
 
 .. automodule:: oqupy.file_formats
     :members:
 
 
-tempo.helpers
+oqupy.helpers
 -------------
 
 .. automodule:: oqupy.helpers
     :members:
 
 
-tempo.operators
+oqupy.operators
 ---------------
 
 .. automodule:: oqupy.operators
     :members:
 
 
-tempo.process_tensor
+oqupy.process_tensor
 --------------------
 
 .. automodule:: oqupy.process_tensor
@@ -69,7 +77,7 @@ tempo.process_tensor
     :members:
 
 
-tempo.pt_tempo
+oqupy.pt_tempo
 --------------
 
 .. automodule:: oqupy.pt_tempo
@@ -77,7 +85,7 @@ tempo.pt_tempo
     :members:
 
 
-tempo.system
+oqupy.system
 ------------
 
 .. automodule:: oqupy.system
@@ -85,7 +93,7 @@ tempo.system
     :members:
 
 
-tempo.tempo
+oqupy.tempo
 -----------
 
 .. automodule:: oqupy.tempo
@@ -93,14 +101,14 @@ tempo.tempo
     :members:
 
 
-tempo.util
+oqupy.util
 ----------
 
 .. automodule:: oqupy.util
     :members:
 
 
-tempo.backends
+oqupy.backends
 --------------
 
 base_backends

--- a/examples/00-system-correlations.py
+++ b/examples/00-system-correlations.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import sys
+sys.path.insert(0,'.')
+
+import numpy as np
+import matplotlib.pyplot as plt
+from IPython import embed
+
+import oqupy
+import oqupy.operators as op
+
+
+# -----------------------------------------------------------------------------
+
+omega_cutoff = 3.04
+alpha = 0.126
+temperature = 0.1309
+initial_state=op.spin_dm("z-")
+
+def gaussian_shape(t, area = 1.0, tau = 1.0, t_0 = 0.0):
+    return area/(tau*np.sqrt(np.pi)) * np.exp(-(t-t_0)**2/(tau**2))
+
+detuning = lambda t: 0.0 * t
+
+t = np.linspace(-2,3,100)
+Omega_t = gaussian_shape(t, area = np.pi/2.0, tau = 0.245)
+Delta_t = detuning(t)
+
+correlations = oqupy.PowerLawSD(alpha=alpha,
+                                zeta=3,
+                                cutoff=omega_cutoff,
+                                cutoff_type='gaussian',
+                                max_correlation_time=5.0,
+                                temperature=temperature)
+bath = oqupy.Bath(op.sigma("z")/2.0, correlations)
+
+pt_tempo_parameters = oqupy.PtTempoParameters(
+    dt=0.10,
+    dkmax=40,
+    epsrel=10**(-5))
+start_time = -1.0
+process_tensor = oqupy.pt_tempo_compute(bath=bath,
+                                        start_time=start_time,
+                                        end_time=1.0,
+                                        parameters=pt_tempo_parameters)
+
+def hamiltonian_t(t, delta=0.0):
+    return delta/2.0 * op.sigma("z") \
+        + gaussian_shape(t, area = np.pi/2.0, tau = 0.245)/2.0 \
+        * op.sigma("x")
+system = oqupy.TimeDependentSystem(hamiltonian_t)
+
+
+# -----------------------------------------------------------------------------
+
+print("-------- Example A --------")
+
+times_a, times_b, correlations = oqupy.compute_correlations(
+        system=system,
+        process_tensor=process_tensor,
+        operator_a=op.sigma("x"),
+        operator_b=op.sigma("z"),
+        times_a=-0.5,
+        times_b=0.5,
+        time_order="full",
+        initial_state=initial_state,
+        start_time=start_time,
+        progress_type="bar")
+
+print(f"times_a = {times_a}")
+print(f"times_b = {times_b}")
+print("Correlation matrix:")
+print(correlations)
+
+control = oqupy.Control(2)
+control.add_single(5, op.left_super(op.sigma("x")))
+
+s_xy_list = []
+t_list = []
+dynamics = oqupy.compute_dynamics(
+    system=system,
+    process_tensor=process_tensor,
+    control=control,
+    start_time=start_time,
+    initial_state=initial_state)
+t, s_x = dynamics.expectations(op.sigma("x"))
+_, s_y = dynamics.expectations(op.sigma("y"))
+_, s_z = dynamics.expectations(op.sigma("z"))
+
+
+for i, s_xyz in enumerate([s_x, s_y, s_z]):
+    plt.plot(t, s_xyz.real, color=f"C{i}", linestyle="solid")
+    plt.plot(t, s_xyz.imag, color=f"C{i}", linestyle="dotted")
+    plt.xlabel(r'$t/$ps')
+    plt.ylabel(r'$<\sigma_{xyz}>$')
+    plt.scatter(times_b[0],correlations[0, 0].real, color="C2", marker="o")
+    plt.scatter(times_b[0],correlations[0, 0].imag, color="C2", marker="x")
+
+# -----------------------------------------------------------------------------
+
+print("-------- Example B --------")
+
+times_a, times_b, correlations = oqupy.compute_correlations(
+        system=system,
+        process_tensor=process_tensor,
+        operator_a=op.sigma("x"),
+        operator_b=op.sigma("z"),
+        times_a=(-0.4, 0.4),
+        times_b=slice(8, 14),
+        time_order="ordered",
+        initial_state=initial_state,
+        start_time=start_time,
+        progress_type="bar")
+
+print(f"times_a = {times_a}")
+print(f"times_b = {times_b}")
+print("Shape of correlations matrix:")
+print(np.abs(correlations) >= 0.0)
+
+plt.show()

--- a/oqupy/__init__.py
+++ b/oqupy/__init__.py
@@ -50,6 +50,7 @@ __all__ = [
 
 from oqupy.bath import Bath
 
+from oqupy.contractions import compute_correlations
 from oqupy.contractions import compute_dynamics
 from oqupy.contractions import compute_final_state
 


### PR DESCRIPTION
Implement two time system correlation computation(#31). Tests, tutorials, and better examples are still missing.
 
* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/TimeEvolvingMPO/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [ ] Added test for changed/added code.
* [x] API code contributions include input checks.
* [x] API code contributions include helpful error messages.
* [ ] The documentation has been updated:
  - [x] docstring for all functions/methods/classes/modules.
  - [x] consistant style of all docstrings.
  - [ ] for new modules: `/docs/pages/modules.rst` has been updated.
  - [x] for api contributions: `/docs/pages/api.rst` has been updated.
  - [ ] for api contributions: tutorials and examples have been updated.
