### PR TITLE
Pr/bath dyns test

### DIFF
--- a/tests/bath_dynamics_test.py
+++ b/tests/bath_dynamics_test.py
@@ -1,0 +1,118 @@
+# Copyright 2021 The TEMPO Collaboration
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for the oqupy.bath_dynamics module.
+"""
+import numpy as np
+
+from oqupy.bath_dynamics import TwoTimeBathCorrelations
+from oqupy.correlations import PowerLawSD
+from oqupy import PtTempoParameters, System, Bath, PtTempo
+from oqupy.config import NpDtype
+
+def exact_correlation(t_1, t_2, w_1, w_2, dagg,
+               g_1, g_2, temp):
+    #Exact solution of independent boson model mode correlation functions
+    ph_1 = np.exp(1j * (2*dagg[1] - 1) * w_1 * t_1)
+    ph_2 = np.exp(1j * (2*dagg[0] - 1) * w_2 * t_2)
+    out = 0
+    if dagg in ((0, 1), (1, 0)) and w_1 == w_2:
+        out += 1
+        if dagg == (1, 0) and temp > 0:
+            out += (np.exp(w_1/temp) - 1) ** (-1)
+    out *= ph_1 * ph_2
+    out += (ph_1 * ph_2 - ph_1 - ph_2 + 1) * (g_1 * g_2)/(w_1 * w_2)
+    return out
+
+def exact_occupation(t, w, g, temp):
+    #Exact solution of independent boson model mode occupation
+    out = g**2/w**2 * (2 - 2*np.cos(w*t))
+    if temp > 0:
+        out += (np.exp(w/temp) - 1) ** (-1)
+    return out
+
+def test():
+    #Set parameters
+    initial_state = np.array([[1,0],[0,0]])
+    wc = 10.0
+    alpha = 0.1
+    temperature = 2
+    dt = .1
+    dkmax = None
+    final_time = 2
+    epsrel = 1e-7
+    system_correlations = np.ones((int(final_time/dt),                  #system correlations
+                              int(final_time/dt)), dtype = NpDtype)     #are known exactly.
+    correlations = PowerLawSD(alpha=alpha,
+                              zeta=1.0,
+                              cutoff=wc,
+                              cutoff_type="exponential",
+                              temperature=temperature)
+    coupling_operator = np.array([[1,0],[0,-1]])
+    system_hamiltonian = np.array([[1,0],[0,-1]])
+    parameters = PtTempoParameters(dt, dkmax, epsrel)
+    system = System(system_hamiltonian)
+    bath = Bath(coupling_operator,correlations)
+    pt = PtTempo(bath, 0.0, final_time, parameters)
+    pt = pt.get_process_tensor()
+    corr = TwoTimeBathCorrelations(system, bath, pt,
+                                   initial_state = initial_state,
+                                   system_correlations=system_correlations)
+    #Test properties
+    assert corr.system == system
+    assert corr.bath == bath
+    np.testing.assert_equal(corr.initial_state, initial_state)
+
+    tlist, occ_0 = corr.occupation(0)
+
+    np.testing.assert_equal(occ_0,np.ones(len(tlist),
+                                        dtype=NpDtype) * (np.nan + 1.0j*np.nan))
+
+    w0 = 1
+    coup = correlations.spectral_density(w0)
+
+    _, occ = corr.occupation(w0)
+    corr_occ = corr.correlation(w0, tlist[-1], dagg = (0, 1))
+    assert np.allclose(occ[-1],corr_occ - 1)
+    _, occ_change = corr.occupation(w0, change_only = True)
+    exact_occ = exact_occupation(tlist, w0, coup ** 0.5, temperature)
+    exact_occ_T0 = exact_occupation(tlist, w0, coup ** 0.5, 0)
+
+    assert np.allclose(occ, exact_occ)
+    assert np.allclose(occ_change, exact_occ_T0)
+
+    w02 = 3
+    coup2 = correlations.spectral_density(w02)
+
+    for dagg in [(0,0),(0,1),(1,0),(1,1)]:
+        corrs = []
+        int_corrs = []
+        exact_corrs = []
+        sel = 10
+        for t in tlist[sel:]:
+            corrs.append(corr.correlation(w0, tlist[sel], w02, t, dagg = dagg))
+            int_corrs.append(corr.correlation(w0, tlist[sel], w02, t, dagg = dagg,
+                                              interaction_picture=True))
+            exact_corrs.append(exact_correlation(sel*dt, t, w0, w02, dagg,
+                                                 coup**0.5, coup2**0.5,
+                                                 temperature))
+        int_phase = np.exp(-1j * ((2 * dagg[0] - 1) * w02 * tlist[sel:] + \
+                                  (2 * dagg[1] - 1) * w0 * tlist[sel]))
+        assert np.allclose(corrs,exact_corrs)
+        assert np.allclose(int_corrs,exact_corrs * int_phase)
+    corr2 = TwoTimeBathCorrelations(system, bath, pt,
+                                    initial_state=initial_state)
+    corr2.gen_sys_correlations(1)
+    assert np.allclose(corr2._system_correlations[0,:],
+                       np.ones(int(len(tlist)/2)))


### PR DESCRIPTION
Added test comparing bath dynamics to independent boson model result, currently does not really test finite temperature and the results or this model only depend trivially on T. Integration within TwoTimeBathCorrelation was also improved and the code was given a tidy. Finally added gen_sys_correlations that allows calculation (and storing) of system correlations prior to bath corr function calculation.

# Pull Request Check List

This checklist serves as a guid for contributors and maintainers to assess
whether a contribution can be merged into the master branch and thus serves
to guarantee the quality of the package. Please also read the
[contribution guidline](https://github.com/tempoCollaboration/TimeEvolvingMPO/blob/master/CONTRIBUTING.md).

Before you submit a pull request, please go through this checklist once
more, as it will decrease the number of unnecessary review cycles.
However, this list is there to *help* all contributors to produce high
quality code, not to deter you from contributing. If you can't tick some of the
boxes, feel free to submit the pull request anyway and report about it in the
pull request message.

Some of the boxes might not apply to the specific type of your contribution. In
this case you can consider the particular box as checked.

* [x] The contribution has been discussed and agreed on in the [Issue section](https://github.com/tempoCollaboration/TimeEvolvingMPO/issues).
* [x] Code contributions do its best to follow [the zen of python](https://www.python.org/dev/peps/pep-0020/).
* [x] The automated test are all positive:
  - [x] `tox -e py36` (to run `pytest`) the code tests.
  - [x] `tox -e style` (to run `pylint`) the [code style](https://www.python.org/dev/peps/pep-0008/) tests.
  - [x] `tox -e docs` (to run `sphinx`) generate the documentation.
* [x] Added test for changed/added code.
* [ ] API code contributions include input checks.
* [ ] API code contributions include helpful error messages.
* [x] The documentation has been updated:
  - [x] docstring for all functions/methods/classes/modules.
  - [x] consistant style of all docstrings.
  - [ ] for new modules: `/docs/pages/modules.rst` has been updated.
  - [ ] for api contributions: `/docs/pages/api.rst` has been updated.
  - [ ] for api contributions: tutorials and examples have been updated.
